### PR TITLE
Add sample subscription for monitoring LSA protection events

### DIFF
--- a/Subscriptions/LSA Protection.xml
+++ b/Subscriptions/LSA Protection.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Subscription xmlns="http://schemas.microsoft.com/2006/03/windows/events/subscription">
+    <SubscriptionId>Additional LSA Protection</SubscriptionId>
+    <SubscriptionType>SourceInitiated</SubscriptionType>
+    <Description>Events for additional LSA protection issues</Description>
+    <Enabled>false</Enabled>
+    <Uri>http://schemas.microsoft.com/wbem/wsman/1/windows/EventLog</Uri>
+
+    <ConfigurationMode>Custom</ConfigurationMode>
+    <Delivery Mode="Push">
+        <Batching>
+            <MaxItems>1</MaxItems>
+            <MaxLatencyTime>1000</MaxLatencyTime>
+        </Batching>
+        <PushSettings>
+            <Heartbeat Interval="40000"/>
+        </PushSettings>
+    </Delivery>
+
+    <Query>
+        <![CDATA[
+<QueryList>
+  <Query Id="0" Path="Microsoft-Windows-Wininit/Diagnostic">
+    <!-- Code Integrity events -->
+    <Select Path="Microsoft-Windows-CodeIntegrity/Operational">
+      *[System[Provider[@Name='Microsoft-Windows-CodeIntegrity']
+        and (EventID=3033 or EventID=3063 or EventID=3065 or EventID=3066)]]
+    </Select>    
+  </Query>
+
+  <Query Id="1" Path="System">
+    <!-- Process startup events -->
+    <Select Path="System">
+      *[System[Provider[@Name='Microsoft-Windows-Wininit']
+        and (EventID=12)]]
+    </Select>
+  </Query>
+</QueryList>
+        ]]>
+    </Query>
+
+    <ReadExistingEvents>true</ReadExistingEvents>
+    <TransportName>HTTP</TransportName>
+    <ContentFormat>RenderedText</ContentFormat>
+    <Locale Language="en-AU"/>
+    <LogFile>ForwardedEvents</LogFile>
+    <PublisherName>Microsoft-Windows-EventCollector</PublisherName>
+    <AllowedSourceNonDomainComputers></AllowedSourceNonDomainComputers>
+    <AllowedSourceDomainComputers>O:NSG:BAD:P(A;;GA;;;DC)S:</AllowedSourceDomainComputers>
+</Subscription>


### PR DESCRIPTION
Windows 8.1 & Server 2012 R2 introduced a new opt-in security feature,
Additional LSA Protection, which improves the security of the Local
Security Authority (LSA) by configuring the LSASS (LSA Subsystem Service)
as a protected process. This substantially locks down access to the
process from other userland processes, which is of particular use in
defending against credential theft attacks (e.g. mimikatz).

If enabled it's useful to collect some related events:
- Process startup events confirming LSASS started as a protected process
- Code integrity events alerting of blocked drivers due to LSA policy

The latter category also applies to audit events generated in the event a
driver would have been blocked if Additional LSA Protection was enabled in
the case Audit Mode is configured in preparation for enabling the feature.

More details can be found on TechNet:
https://technet.microsoft.com/en-au/library/dn408187.aspx
